### PR TITLE
Add support for scrolling headsigns

### DIFF
--- a/components/transit_tracker/__init__.py
+++ b/components/transit_tracker/__init__.py
@@ -33,6 +33,7 @@ CONF_FEED_CODE = "feed_code"
 CONF_DEFAULT_ROUTE_COLOR = "default_route_color"
 CONF_TIME_DISPLAY = "time_display"
 CONF_LIST_MODE = "list_mode"
+CONF_SCROLL_HEADSIGNS = "scroll_headsigns"
 
 
 def validate_ws_url(value):
@@ -69,6 +70,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_LIST_MODE, default="sequential"): cv.one_of(
                 "sequential", "nextPerRoute"
             ),
+            cv.Optional(CONF_SCROLL_HEADSIGNS, default=False) : cv.boolean,
             cv.Optional(CONF_STOPS, default=[]): cv.ensure_list(
                 cv.Schema(
                     {
@@ -134,6 +136,7 @@ async def to_code(config):
     cg.add(var.set_display_departure_times(display_departure_times))
 
     cg.add(var.set_list_mode(config[CONF_LIST_MODE]))
+    cg.add(var.set_scroll_headsigns(config[CONF_SCROLL_HEADSIGNS]))
 
     cg.add(var.set_limit(config[CONF_LIMIT]))
 

--- a/components/transit_tracker/transit_tracker.cpp
+++ b/components/transit_tracker/transit_tracker.cpp
@@ -279,10 +279,6 @@ void TransitTracker::draw_text_centered_(const char *text, Color color) {
 }
 
 std::string TransitTracker::from_now_(time_t unix_timestamp, uint rtc_now) const {
-  if (this->rtc_ == nullptr) {
-    return "";
-  }
-
   int diff = unix_timestamp - rtc_now;
 
   if (diff < 30) {

--- a/components/transit_tracker/transit_tracker.cpp
+++ b/components/transit_tracker/transit_tracker.cpp
@@ -69,6 +69,7 @@ void TransitTracker::dump_config() {
   ESP_LOGCONFIG(TAG, "  List mode: %s", this->list_mode_.c_str());
   ESP_LOGCONFIG(TAG, "  Display departure times: %s", this->display_departure_times_ ? "true" : "false");
   ESP_LOGCONFIG(TAG, "  Unit display: %s", this->unit_display_ == UNIT_DISPLAY_LONG ? "long" : this->unit_display_ == UNIT_DISPLAY_SHORT ? "short" : "none");
+  ESP_LOGCONFIG(TAG, "  Scroll Headsigns: %s", this->scroll_headsigns_ ? "true" : "false");
 }
 
 void TransitTracker::reconnect() {
@@ -451,8 +452,11 @@ void HOT TransitTracker::draw_schedule() {
     }
 
     int scroll_offset = 0;
-    {
-      /// TODO: The scroll may jump if headsign_clipping_end changes (e.g. due to the width of the arrival time changing).
+    if(this->scroll_headsigns_) {
+      /// Note: The scroll may jump if headsign_clipping_end changes (e.g. due to the width of the arrival time changing).
+      /// This is probably not a big deal, since the display makes sudden changes anyway (e.g. when routes are updated)
+      /// and this happens relatively infrequently.
+
       int headsign_max_width = headsign_clipping_end - headsign_clipping_start;
       int headsign_actual_width, _;
       this->font_->measure(trip.headsign.c_str(), &headsign_actual_width, &_, &_, &_);

--- a/components/transit_tracker/transit_tracker.cpp
+++ b/components/transit_tracker/transit_tracker.cpp
@@ -463,7 +463,7 @@ void HOT TransitTracker::draw_schedule() {
       int overflow_width = headsign_actual_width - headsign_max_width;
       if(overflow_width > 0) {
         constexpr int scroll_speed = 10; // pixels/second
-        constexpr int idle_time_left = 2000;
+        constexpr int idle_time_left = 3000;
         constexpr int idle_time_right = 1000;
 
         long now = millis();

--- a/components/transit_tracker/transit_tracker.cpp
+++ b/components/transit_tracker/transit_tracker.cpp
@@ -463,7 +463,7 @@ void HOT TransitTracker::draw_schedule() {
       int overflow_width = headsign_actual_width - headsign_max_width;
       if(overflow_width > 0) {
         constexpr int scroll_speed = 10; // pixels/second
-        constexpr int idle_time_left = 3000;
+        constexpr int idle_time_left = 5000;
         constexpr int idle_time_right = 1000;
 
         long now = millis();

--- a/components/transit_tracker/transit_tracker.cpp
+++ b/components/transit_tracker/transit_tracker.cpp
@@ -425,7 +425,7 @@ void TransitTracker::draw_trip(
     }
 
     int scroll_offset = 0;
-    if(headsign_overflow > 0 && scroll_cycle_duration > 0) {
+    if (headsign_overflow > 0 && scroll_cycle_duration > 0) {
       /// Note: The scroll may jump if headsign_clipping_end changes (e.g. due to the width of the arrival time changing).
       /// This is probably not a big deal, since the display makes sudden changes anyway (e.g. when routes are updated)
       /// and this happens relatively infrequently.
@@ -436,27 +436,19 @@ void TransitTracker::draw_trip(
       // Scroll idle (left side - default)
       if(scroll_cycle_time < idle_time_left) {
         // scroll_offset = 0; do nothing
-      }
-
-      // Scrolling left
-      else if(scroll_cycle_time < idle_time_left + scroll_time) {
+      } else if (scroll_cycle_time < idle_time_left + scroll_time) {
+        // Scrolling left
         int time_since_scroll_start = scroll_cycle_time - idle_time_left;
         scroll_offset = time_since_scroll_start * scroll_speed / 1000;
-      }
-
-      // Scroll idle (right side)
-      else if(scroll_cycle_time < idle_time_left + scroll_time + idle_time_right) {
+      } else if (scroll_cycle_time < idle_time_left + scroll_time + idle_time_right) {
+        // Scroll idle (right side)
         scroll_offset = headsign_overflow;
-      }
-
-      // Scrolling right
-      else if (scroll_cycle_time < idle_time_left + 2*scroll_time + idle_time_right){
+      } else if (scroll_cycle_time < idle_time_left + 2 * scroll_time + idle_time_right){
+        // Scrolling right
         int time_since_scroll_start = scroll_cycle_time - (idle_time_left + scroll_time + idle_time_right);
         scroll_offset = headsign_overflow - (time_since_scroll_start * scroll_speed / 1000);
-      }
-
-      // Waiting for other headsigns to finish scrolling
-      else {
+      } else {
+        // Waiting for other headsigns to finish scrolling
         // scroll_offset = 0; do nothing
       }
     }
@@ -528,7 +520,6 @@ void HOT TransitTracker::draw_schedule() {
     }
   }
 
-  int y_offset = 2;
   for (const Trip &trip : this->schedule_state_.trips) {
     this->draw_trip(trip, y_offset, nominal_font_height, uptime, rtc_now, false, nullptr, scroll_cycle_duration);
     y_offset += nominal_font_height;

--- a/components/transit_tracker/transit_tracker.h
+++ b/components/transit_tracker/transit_tracker.h
@@ -59,9 +59,15 @@ class TransitTracker : public Component {
     void set_route_styles_from_text(const std::string &text);
 
   protected:
+    static constexpr int scroll_speed = 10; // pixels/second
+    static constexpr int idle_time_left = 5000;
+    static constexpr int idle_time_right = 1000;
+
     std::string from_now_(time_t unix_timestamp) const;
     void draw_text_centered_(const char *text, Color color);
     void draw_realtime_icon_(int bottom_right_x, int bottom_right_y);
+
+    void draw_trip(const Trip &trip, int y_offset, int font_height, bool no_draw = false, int *headsign_overflow_out = nullptr, int scroll_cycle_duration = 0);
 
     ScheduleState schedule_state_;
 

--- a/components/transit_tracker/transit_tracker.h
+++ b/components/transit_tracker/transit_tracker.h
@@ -63,11 +63,14 @@ class TransitTracker : public Component {
     static constexpr int idle_time_left = 5000;
     static constexpr int idle_time_right = 1000;
 
-    std::string from_now_(time_t unix_timestamp) const;
+    std::string from_now_(time_t unix_timestamp, uint rtc_now) const;
     void draw_text_centered_(const char *text, Color color);
-    void draw_realtime_icon_(int bottom_right_x, int bottom_right_y);
+    void draw_realtime_icon_(int bottom_right_x, int bottom_right_y, unsigned long now);
 
-    void draw_trip(const Trip &trip, int y_offset, int font_height, bool no_draw = false, int *headsign_overflow_out = nullptr, int scroll_cycle_duration = 0);
+    void draw_trip(
+      const Trip &trip, int y_offset, int font_height, unsigned long uptime, uint rtc_now,
+      bool no_draw = false, int *headsign_overflow_out = nullptr, int scroll_cycle_duration = 0
+    );
 
     ScheduleState schedule_state_;
 

--- a/components/transit_tracker/transit_tracker.h
+++ b/components/transit_tracker/transit_tracker.h
@@ -48,6 +48,7 @@ class TransitTracker : public Component {
     void set_schedule_string(const std::string &schedule_string) { schedule_string_ = schedule_string; }
     void set_list_mode(const std::string &list_mode) { list_mode_ = list_mode; }
     void set_limit(int limit) { limit_ = limit; }
+    void set_scroll_headsigns(bool scroll_headsigns) { scroll_headsigns_ = scroll_headsigns; }
 
     void set_unit_display(UnitDisplay unit_display) { unit_display_ = unit_display; }
     void add_abbreviation(const std::string &from, const std::string &to) { abbreviations_[from] = to; }
@@ -89,6 +90,7 @@ class TransitTracker : public Component {
     std::map<std::string, std::string> abbreviations_;
     Color default_route_color_ = Color(0x028e51);
     std::map<std::string, RouteStyle> route_styles_;
+    bool scroll_headsigns_ = false;
 };
 
 


### PR DESCRIPTION
This adds basic support for scrolling headsigns, when the headsign is too long to fit on the display. It is enabled by setting the `scroll_headsigns` config property to `true`.

The scrolling behavior is:
* Pause for 5 seconds in the original position
* Scroll to the end of the headsign at a steady rate
* Pause for 1 second at the end of the headsign
* Scroll back to the start of the headsign at a steady rate
* Wait for all other headsigns to finish scrolling