### PR TITLE
Show multiple times per route-stop

### DIFF
--- a/components/transit_tracker/__init__.py
+++ b/components/transit_tracker/__init__.py
@@ -68,7 +68,7 @@ CONFIG_SCHEMA = cv.All(
                 "departure", "arrival"
             ),
             cv.Optional(CONF_LIST_MODE, default="sequential"): cv.one_of(
-                "sequential", "nextPerRoute"
+                "sequential", "nextPerRoute", "doubleTime"
             ),
             cv.Optional(CONF_SCROLL_HEADSIGNS, default=False) : cv.boolean,
             cv.Optional(CONF_STOPS, default=[]): cv.ensure_list(
@@ -135,7 +135,15 @@ async def to_code(config):
     display_departure_times = config[CONF_TIME_DISPLAY] == "departure"
     cg.add(var.set_display_departure_times(display_departure_times))
 
-    cg.add(var.set_list_mode(config[CONF_LIST_MODE]))
+    list_mode_conf = config[CONF_LIST_MODE]
+    
+    if list_mode_conf == "doubleTime":
+        cg.add(var.set_list_mode("sequential"))
+        cg.add(var.set_double_time(True))
+    else:
+        cg.add(var.set_list_mode(list_mode_conf))
+        cg.add(var.set_double_time(False))
+
     cg.add(var.set_scroll_headsigns(config[CONF_SCROLL_HEADSIGNS]))
 
     cg.add(var.set_limit(config[CONF_LIMIT]))

--- a/components/transit_tracker/schedule_state.h
+++ b/components/transit_tracker/schedule_state.h
@@ -11,6 +11,7 @@ namespace transit_tracker {
 class Trip {
   public:
     std::string route_id;
+    std::string stop_id;
     std::string route_name;
     Color route_color;
     std::string headsign;

--- a/components/transit_tracker/transit_tracker.cpp
+++ b/components/transit_tracker/transit_tracker.cpp
@@ -608,7 +608,7 @@ void HOT TransitTracker::draw_schedule() {
 
   // Calculate vertical centering
   int num_rows_on_page = end_idx - start_idx;
-  int max_trips_height = (num_rows_on_page * this->font_->get_ascender()) + ((num_rows_on_page - 1) * this->font_->get_descender());
+  int max_trips_height = num_rows_on_page * nominal_font_height - this->font_->get_descender();
   int y_offset = (this->display_->get_height() - max_trips_height) / 2;
   if (y_offset < 0) y_offset = 0;
 
@@ -691,7 +691,7 @@ void HOT TransitTracker::draw_schedule() {
     }
     
     // Draw headsign with clipping
-    this->display_->start_clipping(headsign_clipping_start, y_offset, headsign_clipping_end, y_offset + nominal_font_height);
+    this->display_->start_clipping(headsign_clipping_start, y_offset - 2, headsign_clipping_end, y_offset + nominal_font_height + 2);
     this->display_->print(headsign_clipping_start - scroll_offset, y_offset, this->font_, row.primary_trip->headsign.c_str());
     this->display_->end_clipping();
     

--- a/components/transit_tracker/transit_tracker.cpp
+++ b/components/transit_tracker/transit_tracker.cpp
@@ -524,11 +524,15 @@ void HOT TransitTracker::draw_schedule() {
   // Calculate baseline time width for stable layout
   int baseline_time_width, _;
   this->font_->measure("99m", &baseline_time_width, &_, &_, &_);
-  int total_times_width = this->double_time_ ? (baseline_time_width * 2 + 3 + 16) : (baseline_time_width + 8);
+  int total_times_width = this->double_time_ ? (baseline_time_width * 2 + 3) : (baseline_time_width + 8);
 
   int num_total_rows = this->display_rows_.size();
   int num_pages = (num_total_rows + items_per_page - 1) / items_per_page;
   if (num_pages < 1) num_pages = 1;
+
+  if (!this->double_time_) {
+    this->page_index_ = 0;
+  }
 
   int start_idx = (this->page_index_ % num_pages) * items_per_page;
   int end_idx = std::min(start_idx + items_per_page, num_total_rows);
@@ -565,7 +569,7 @@ void HOT TransitTracker::draw_schedule() {
   int scroll_cycle_duration = calc_scroll_duration(start_idx, end_idx);
   int page_dwell = std::max(5000, scroll_cycle_duration);
 
-  if (uptime - this->last_page_change_ > (unsigned long)page_dwell) {
+  if (this->double_time_ && uptime - this->last_page_change_ > (unsigned long)page_dwell) {
       this->page_index_ = (this->page_index_ + 1) % num_pages;
       this->last_page_change_ = uptime;
       this->scroll_cycle_start_ = uptime;
@@ -616,7 +620,7 @@ void HOT TransitTracker::draw_schedule() {
       if (!time_str.empty()) {
         this->display_->print(time_x, y_offset, this->font_, color, display::TextAlign::TOP_RIGHT, time_str.c_str());
 
-        if (i < row.trips.size() && row.trips[i]->is_realtime) {
+        if (!this->double_time_ && i < row.trips.size() && row.trips[i]->is_realtime) {
            int icon_x = time_x - w - 8;
            int icon_y = y_offset + nominal_font_height - 11;
            this->draw_realtime_icon_(icon_x, icon_y, icon_frame);

--- a/components/transit_tracker/transit_tracker.h
+++ b/components/transit_tracker/transit_tracker.h
@@ -49,6 +49,7 @@ class TransitTracker : public Component {
     void set_list_mode(const std::string &list_mode) { list_mode_ = list_mode; }
     void set_limit(int limit) { limit_ = limit; }
     void set_scroll_headsigns(bool scroll_headsigns) { scroll_headsigns_ = scroll_headsigns; }
+    void set_double_time(bool double_time) { double_time_ = double_time; }
 
     void set_unit_display(UnitDisplay unit_display) { unit_display_ = unit_display; }
     void add_abbreviation(const std::string &from, const std::string &to) { abbreviations_[from] = to; }
@@ -70,7 +71,7 @@ class TransitTracker : public Component {
 
     std::string from_now_(time_t unix_timestamp, uint rtc_now) const;
     void draw_text_centered_(const char *text, Color color);
-    void draw_realtime_icon_(int bottom_right_x, int bottom_right_y, unsigned long now);
+    void draw_realtime_icon_(int x, int y, int frame);
 
     void draw_trip(
       const Trip &trip, int y_offset, int font_height, unsigned long uptime, uint rtc_now,
@@ -108,10 +109,16 @@ class TransitTracker : public Component {
     Color default_route_color_ = Color(0x028e51);
     std::map<std::string, RouteStyle> route_styles_;
     bool scroll_headsigns_ = false;
+    bool double_time_ = false;
 
     // Cached scroll state to prevent mid-cycle jumps
     unsigned long scroll_cycle_start_ = 0;
     int cached_scroll_cycle_duration_ = 0;
+
+    // Pagination
+    int page_index_ = 0;
+    unsigned long last_page_change_ = 0;
+    static constexpr int items_per_page = 3;
 };
 
 

--- a/components/transit_tracker/transit_tracker.h
+++ b/components/transit_tracker/transit_tracker.h
@@ -66,8 +66,8 @@ class TransitTracker : public Component {
 
   protected:
     static constexpr int scroll_speed = 10; // pixels/second
-    static constexpr int idle_time_left = 5000;
-    static constexpr int idle_time_right = 1000;
+    static constexpr int idle_time_left = 8000;
+    static constexpr int idle_time_right = 2000;
 
     std::string from_now_(time_t unix_timestamp, uint rtc_now) const;
     void draw_text_centered_(const char *text, Color color);

--- a/components/transit_tracker/transit_tracker.h
+++ b/components/transit_tracker/transit_tracker.h
@@ -58,6 +58,11 @@ class TransitTracker : public Component {
     void set_abbreviations_from_text(const std::string &text);
     void set_route_styles_from_text(const std::string &text);
 
+    struct DisplayRow {
+      const Trip* primary_trip;
+      std::vector<const Trip*> trips;
+    };
+
   protected:
     static constexpr int scroll_speed = 10; // pixels/second
     static constexpr int idle_time_left = 5000;
@@ -71,6 +76,9 @@ class TransitTracker : public Component {
       const Trip &trip, int y_offset, int font_height, unsigned long uptime, uint rtc_now,
       bool no_draw = false, int *headsign_overflow_out = nullptr, int scroll_cycle_duration = 0
     );
+
+    void update_display_rows_();
+    std::vector<DisplayRow> display_rows_;
 
     ScheduleState schedule_state_;
 
@@ -100,6 +108,10 @@ class TransitTracker : public Component {
     Color default_route_color_ = Color(0x028e51);
     std::map<std::string, RouteStyle> route_styles_;
     bool scroll_headsigns_ = false;
+
+    // Cached scroll state to prevent mid-cycle jumps
+    unsigned long scroll_cycle_start_ = 0;
+    int cached_scroll_cycle_duration_ = 0;
 };
 
 

--- a/components/transit_tracker/transit_tracker.h
+++ b/components/transit_tracker/transit_tracker.h
@@ -113,7 +113,6 @@ class TransitTracker : public Component {
 
     // Cached scroll state to prevent mid-cycle jumps
     unsigned long scroll_cycle_start_ = 0;
-    int cached_scroll_cycle_duration_ = 0;
 
     // Pagination
     int page_index_ = 0;

--- a/examples/matrix-portal-s3.yaml
+++ b/examples/matrix-portal-s3.yaml
@@ -83,8 +83,8 @@ color:
 transit_tracker:
   id: tracker
   base_url: "wss://tt.horner.tj/"
-  limit: 10
-  list_mode: "sequential"
+  limit: 12
+  list_mode: "doubleTime"
   scroll_headsigns: true
   show_units: "short"
   stops:

--- a/examples/matrix-portal-s3.yaml
+++ b/examples/matrix-portal-s3.yaml
@@ -3,7 +3,7 @@ esphome:
   friendly_name: Transit Tracker
 
 esp32:
-  board: esp32-s3-devkitc-1
+  board: adafruit-matrixportal-esp32s3
   framework:
     type: arduino
 
@@ -75,45 +75,28 @@ time:
 color:
   - id: rapidride_red
     hex: "F50046"
-  - id: e_line_red
-    hex: "9C182F"
-  - id: route_44_purple
-    hex: "840AFD"
 
 transit_tracker:
   id: tracker
   base_url: "wss://tt.horner.tj/"
-  limit: 12
-  #list_mode: "nextPerRoute"
-  #list_mode: "sequential"
-  list_mode: "doubleTime"
-  scroll_headsigns: true
-  show_units: "short"
-  #show_units: "long"
-  #show_units: "none"
+  limit: 3
+  feed_code: "st"
   stops:
-    - stop_id: "st:1_29557"
+    - stop_id: "1_71971" # Redmond Way & Bear Creek Pkwy
+      time_offset: -8min
       routes:
-        - "st:1_100224"
-    - stop_id: "st:1_29231"
+        - "1_100113" # 221
+        - "1_102704" # 250
+    - stop_id: "1_71961" # RTC
+      time_offset: -10min
       routes:
-        - "st:1_100224"
-    - stop_id: "st:1_75408"
-      routes:
-        - "st:1_102615"
+        - "1_102548" # B Line
   styles:
-    - route_id: "st:1_102615"
-      name: "E"
-      color: e_line_red
-    - route_id: "st:1_100224"
-      name: "44"
-      color: route_44_purple
+    - route_id: "1_102548"
+      name: "B"
+      color: rapidride_red
   abbreviations:
-    - from: "Seattle"
-      to: ""
-    - from: "Ballard Wallingford"
-      to: "Ballard - 46th & Stone"
-    - from: "University Of Washington Medical Center Wallingford"
-      to: "UW - 45th & Greenlake "
-    - from: "University District"
-      to: "UW - 45th & Greenlake "
+    - from: "Bellevue Transit Center Crossroads"
+      to: "Bellevue TC"
+    - from: "Transit Center"
+      to: "TC"

--- a/examples/matrix-portal-s3.yaml
+++ b/examples/matrix-portal-s3.yaml
@@ -84,9 +84,13 @@ transit_tracker:
   id: tracker
   base_url: "wss://tt.horner.tj/"
   limit: 12
+  #list_mode: "nextPerRoute"
+  #list_mode: "sequential"
   list_mode: "doubleTime"
   scroll_headsigns: true
   show_units: "short"
+  #show_units: "long"
+  #show_units: "none"
   stops:
     - stop_id: "st:1_29557"
       routes:

--- a/examples/matrix-portal-s3.yaml
+++ b/examples/matrix-portal-s3.yaml
@@ -97,9 +97,6 @@ transit_tracker:
     - stop_id: "st:1_75408"
       routes:
         - "st:1_102615"
-    - stop_id: "st:40_990002"
-      routes:
-        - "st:40_100479"
   styles:
     - route_id: "st:1_102615"
       name: "E"

--- a/examples/matrix-portal-s3.yaml
+++ b/examples/matrix-portal-s3.yaml
@@ -54,7 +54,8 @@ display:
     OE_pin: 14
     CLK_pin: 2
     clock_phase: false
-    i2sspeed: HZ_20M
+    i2sspeed: HZ_10M
+    latch_blanking: 4
     brightness: 255
     lambda: |-
       id(tracker).draw_schedule();

--- a/examples/matrix-portal-s3.yaml
+++ b/examples/matrix-portal-s3.yaml
@@ -3,7 +3,7 @@ esphome:
   friendly_name: Transit Tracker
 
 esp32:
-  board: adafruit-matrixportal-esp32s3
+  board: esp32-s3-devkitc-1
   framework:
     type: arduino
 
@@ -75,28 +75,40 @@ time:
 color:
   - id: rapidride_red
     hex: "F50046"
+  - id: e_line_red
+    hex: "9C182F"
+  - id: route_44_purple
+    hex: "840AFD"
 
 transit_tracker:
   id: tracker
   base_url: "wss://tt.horner.tj/"
-  limit: 3
-  feed_code: "st"
+  limit: 10
+  scroll_headsigns: true
+  show_units: "short"
   stops:
-    - stop_id: "1_71971" # Redmond Way & Bear Creek Pkwy
-      time_offset: -8min
+    - stop_id: "st:1_75408"
       routes:
-        - "1_100113" # 221
-        - "1_102704" # 250
-    - stop_id: "1_71961" # RTC
-      time_offset: -10min
+        - "st:1_102615"
+    - stop_id: "st:1_29557"
       routes:
-        - "1_102548" # B Line
+        - "st:1_100224"
+    - stop_id: "st:1_29231"
+      routes:
+        - "st:1_100224"
   styles:
-    - route_id: "1_102548"
-      name: "B"
-      color: rapidride_red
+    - route_id: "st:1_102615"
+      name: "E"
+      color: e_line_red
+    - route_id: "st:1_100224"
+      name: "44"
+      color: route_44_purple
   abbreviations:
-    - from: "Bellevue Transit Center Crossroads"
-      to: "Bellevue TC"
-    - from: "Transit Center"
-      to: "TC"
+    - from: "Seattle"
+      to: ""
+    - from: "Ballard Wallingford"
+      to: "Ballard - 46th & Stone"
+    - from: "University Of Washington Medical Center Wallingford"
+      to: "UW - 45th & Greenlake "
+    - from: "University District"
+      to: "UW - 45th & Greenlake "

--- a/examples/matrix-portal-s3.yaml
+++ b/examples/matrix-portal-s3.yaml
@@ -84,18 +84,22 @@ transit_tracker:
   id: tracker
   base_url: "wss://tt.horner.tj/"
   limit: 10
+  list_mode: "sequential"
   scroll_headsigns: true
   show_units: "short"
   stops:
-    - stop_id: "st:1_75408"
-      routes:
-        - "st:1_102615"
     - stop_id: "st:1_29557"
       routes:
         - "st:1_100224"
     - stop_id: "st:1_29231"
       routes:
         - "st:1_100224"
+    - stop_id: "st:1_75408"
+      routes:
+        - "st:1_102615"
+    - stop_id: "st:40_990002"
+      routes:
+        - "st:40_100479"
   styles:
     - route_id: "st:1_102615"
       name: "E"


### PR DESCRIPTION
I live by 4 bus routes and have a public transit tracker for my neighborhood. I found the default settings a bit limiting on useful information so I added a list_mode called `doubleTime` that groups results by route-stop and shows the 2 soonest times.  

4 notes for this approach

1. The route / stops don't rotate beyond the first 3 assuming any upcoming arrival is available for each route / stop.  I added pagination behvavior to show 3 routes / stops per page if there are more than 3 routes / stops configured but this behavior may not be desired. 
2. I made the real time icon conditional and it doesn't display when the doubleTime view is active for a better use of space. 
3. Not shown but removing the real time icon and displaying 2 times resulted in some weird row flickering which part of the code changes account for
4. I'm not sure if it is the custom firmware but the brightness button functionality stopped working. I coded it back locally but didn't include in this PR. 

**This functionality does add a fair bit of code and full disclosure I vibe coded it today so happy to close and keep as a personal customization.** 

![IMG_0240](https://github.com/user-attachments/assets/80acc662-34f0-4aba-a9a4-c60027baa700)
![IMG_0241](https://github.com/user-attachments/assets/5be7a099-094e-496d-9fcf-459d3fa131ed)