### PR TITLE
Add pagination to display more trips

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,14 @@ transit_tracker:
   # The feed code of the transit agency you want to track (optional)
   feed_code: "st"
 
-  # Maximum number of arrivals to show
+  # Maximum number of arrivals to show at once
   limit: 3
+
+  # Total number of trips to fetch from the server. If greater than 'limit', trips are split across multiple pages
+  trips: 3
+
+  # Duration each page of trips is displayed before switching to the next
+  page_duration: 15s
 
   # Whether to display arrival or departure times
   time_display: departure # or "arrival"

--- a/components/transit_tracker/__init__.py
+++ b/components/transit_tracker/__init__.py
@@ -28,6 +28,8 @@ CONF_STOPS = "stops"
 CONF_BASE_URL = "base_url"
 CONF_FONT_ID = "font_id"
 CONF_LIMIT = "limit"
+CONF_TRIPS = "trips"
+CONF_PAGE_DURATION = "page_duration"
 CONF_ABBREVIATIONS = "abbreviations"
 CONF_STYLES = "styles"
 CONF_FEED_CODE = "feed_code"
@@ -79,6 +81,8 @@ CONFIG_SCHEMA = cv.All(
             cv.GenerateID(CONF_TIME_ID): cv.use_id(RealTimeClock),
             cv.Optional(CONF_BASE_URL): validate_ws_url,
             cv.Optional(CONF_LIMIT, default=3): cv.positive_int,
+            cv.Optional(CONF_TRIPS, default=3): cv.positive_int,
+            cv.Optional(CONF_PAGE_DURATION, default="10s"): cv.positive_time_period_milliseconds,
             cv.Optional(CONF_FEED_CODE, default=""): cv.string,
             cv.Optional(CONF_TIME_DISPLAY, default="departure"): cv.one_of(
                 "departure", "arrival"
@@ -157,6 +161,8 @@ async def to_code(config):
     cg.add(var.set_scroll_headsigns(config[CONF_SCROLL_HEADSIGNS]))
 
     cg.add(var.set_limit(config[CONF_LIMIT]))
+    cg.add(var.set_trips(config[CONF_TRIPS]))
+    cg.add(var.set_page_duration(config[CONF_PAGE_DURATION]))
 
     cg.add(var.set_unit_display(config[CONF_SHOW_UNITS]))
 

--- a/components/transit_tracker/transit_tracker.cpp
+++ b/components/transit_tracker/transit_tracker.cpp
@@ -66,6 +66,8 @@ void TransitTracker::dump_config() {
   ESP_LOGCONFIG(TAG, "  Base URL: %s", this->base_url_.c_str());
   ESP_LOGCONFIG(TAG, "  Schedule: %s", this->schedule_string_.c_str());
   ESP_LOGCONFIG(TAG, "  Limit: %d", this->limit_);
+  ESP_LOGCONFIG(TAG, "  Trips: %d", this->trips_);
+  ESP_LOGCONFIG(TAG, "  Page duration: %u ms", this->page_duration_);
   ESP_LOGCONFIG(TAG, "  List mode: %s", this->list_mode_.c_str());
   ESP_LOGCONFIG(TAG, "  Display departure times: %s", this->display_departure_times_ ? "true" : "false");
   ESP_LOGCONFIG(TAG, "  Scroll Headsigns: %s", this->scroll_headsigns_ ? "true" : "false");
@@ -170,7 +172,11 @@ void TransitTracker::on_ws_event_(websockets::WebsocketsEvent event, String data
       }
 
       data["routeStopPairs"] = this->schedule_string_;
-      data["limit"] = this->limit_;
+      if (this->trips_ > this->limit_) {
+        data["limit"] = this->trips_;
+      } else {
+        data["limit"] = this->limit_;
+      }
       data["sortByDeparture"] = this->display_departure_times_;
       data["listMode"] = this->list_mode_;
     });
@@ -473,12 +479,20 @@ void HOT TransitTracker::draw_schedule() {
   unsigned long uptime = millis();
   uint rtc_now = this->rtc_->now().timestamp;
 
+  int total_trips = this->schedule_state_.trips.size();
+  // Division rounding up to determine total pages
+  int total_pages = (total_trips + this->limit_ - 1) / this->limit_;
+  int current_page = (uptime / this->page_duration_) % total_pages;
+
+  int start_idx = current_page * this->limit_;
+  int end_idx = std::min(start_idx + this->limit_, total_trips);
+
   int scroll_cycle_duration = 0;
   if (this->scroll_headsigns_) {
     int largest_headsign_overflow = 0;
-    for (const Trip &trip : this->schedule_state_.trips) {
+    for (int i = start_idx; i < end_idx; ++i) {
       int headsign_overflow;
-      this->draw_trip(trip, 0, nominal_font_height, uptime, rtc_now, true, &headsign_overflow);
+      this->draw_trip(this->schedule_state_.trips[i], 0, nominal_font_height, uptime, rtc_now, true, &headsign_overflow);
       largest_headsign_overflow = max(largest_headsign_overflow, headsign_overflow);
     }
 
@@ -491,8 +505,8 @@ void HOT TransitTracker::draw_schedule() {
   int max_trips_height = (this->limit_ * this->font_->get_ascender()) + ((this->limit_ - 1) * this->font_->get_descender());
   int y_offset = (this->display_->get_height() % max_trips_height) / 2;
 
-  for (const Trip &trip : this->schedule_state_.trips) {
-    this->draw_trip(trip, y_offset, nominal_font_height, uptime, rtc_now, false, nullptr, scroll_cycle_duration);
+  for (int i = start_idx; i < end_idx; ++i) {
+    this->draw_trip(this->schedule_state_.trips[i], y_offset, nominal_font_height, uptime, rtc_now, false, nullptr, scroll_cycle_duration);
     y_offset += nominal_font_height;
   }
 

--- a/components/transit_tracker/transit_tracker.h
+++ b/components/transit_tracker/transit_tracker.h
@@ -45,6 +45,8 @@ class TransitTracker : public Component {
     void set_schedule_string(const std::string &schedule_string) { schedule_string_ = schedule_string; }
     void set_list_mode(const std::string &list_mode) { list_mode_ = list_mode; }
     void set_limit(int limit) { limit_ = limit; }
+    void set_trips(int trips) { trips_ = trips; }
+    void set_page_duration(uint32_t page_duration) { page_duration_ = page_duration; }
     void set_scroll_headsigns(bool scroll_headsigns) { scroll_headsigns_ = scroll_headsigns; }
 
     void set_unit_display(UnitDisplay unit_display) { this->localization_.set_unit_display(unit_display); }
@@ -94,6 +96,8 @@ class TransitTracker : public Component {
     std::string list_mode_;
     bool display_departure_times_ = true;
     int limit_;
+    int trips_;
+    uint32_t page_duration_ = 10000;
 
     std::map<std::string, std::string> abbreviations_;
     Color default_route_color_ = Color(0x028e51);


### PR DESCRIPTION
### Overview
This PR introduces pagination, allowing to display a larger number of trips than what can fit on the screen at once. 

I actually implemented this for my own use case before noticing that a similar PR was opened some time ago. The approaches used here and in #6 are slightly different though. Feel free to close this if you prefer the other implementation or adjust / take inspiration if you'd like.

**Config changes**
* `limit`: Dictates how many trips fit on the screen at once.
* `trips` (default 3): If trips > limit: the actual WS 'limit' param gets overwritten by the trips number. This is potentially a bit confusing, but ensures backwards compatibility.
* `page_duration` (default 10s): How long each page is displayed before cycling to the next one.

**Usage:**
```yaml
transit_tracker:
  limit: 3                 # Max items on screen at once
  trips: 6                 # Request 6 total items from backend
  page_duration: 15s       # Switch page every 15 seconds
```

I've tested them in various combinations. I also made sure that they're backwards compatible with pre-existing configs.

**Disclosure**
I used AI to help with parts of this implementation.